### PR TITLE
Use uv inline script metadata instead of system pip install for pyyaml

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Python 3.10+
-- PyYAML (`pip install pyyaml`)
+- [uv](https://docs.astral.sh/uv/) (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
 
 ## Install
 

--- a/skills/conversation-compiler/SKILL.md
+++ b/skills/conversation-compiler/SKILL.md
@@ -10,7 +10,7 @@ Compile Claude Code JSONL logs into adaptive views for reading, searching, and c
 ## Usage
 
 ```bash
-python "path/to/VCC.py" <input.jsonl ...> [options]
+uv run "path/to/VCC.py" <input.jsonl ...> [options]
 ```
 
 | Option | Description |
@@ -23,7 +23,7 @@ python "path/to/VCC.py" <input.jsonl ...> [options]
 This tool also supports multi-file processing:
 
 ```bash
-cd "/path/to/target/folder" && python "path/to/VCC.py" *.jsonl --grep "keyword"
+cd "/path/to/target/folder" && uv run "path/to/VCC.py" *.jsonl --grep "keyword"
 ```
 
 ## Output Files
@@ -46,7 +46,7 @@ cd "/path/to/target/folder" && python "path/to/VCC.py" *.jsonl --grep "keyword"
 **1. Compile**
 
 ```bash
-python "path/to/VCC.py" "path/to/conversation.jsonl"
+uv run "path/to/VCC.py" "path/to/conversation.jsonl"
 ```
 
 Produces `.txt` + `.min.txt` next to the input file. Long conversations are automatically split into numbered chunks. The console output lists every produced file with line/word counts — read it to understand the conversation's size and structure before proceeding:
@@ -85,7 +85,7 @@ Each `*` line shows the tool name, key parameter, and two `.txt` line ranges: th
 Always use `--grep`, never system grep nor your embedded Grep tool. This script's `--grep` returns important block-level line RANGES that no other grep tools can provide. The output paths are relative to CWD, so `cd` close to the target first to keep outputs short and save tokens.
 
 ```bash
-cd "/path/to/target/folder" && python "path/to/VCC.py" "path/to/conversation.jsonl" --grep "keyword"
+cd "/path/to/target/folder" && uv run "path/to/VCC.py" "path/to/conversation.jsonl" --grep "keyword"
 ```
 
 Stdout example (`#` prefix = shortened filename)：
@@ -116,10 +116,10 @@ All line references point to `.txt`. Read the referenced range for full context.
 **Action**:
 
 1. `ls ~/.claude/projects/` — browse project directories, narrow the search area.
-2. `cd ~/.claude/projects/<project> && python "absolute/path/to/VCC.py" *.jsonl --grep "keyword"` — search top-level conversations first.
-3. If no results: `cd ~/.claude/projects/<project> && python "absolute/path/to/VCC.py" **/*.jsonl --grep "keyword"` — expand to subagents.
+2. `cd ~/.claude/projects/<project> && uv run "absolute/path/to/VCC.py" *.jsonl --grep "keyword"` — search top-level conversations first.
+3. If no results: `cd ~/.claude/projects/<project> && uv run "absolute/path/to/VCC.py" **/*.jsonl --grep "keyword"` — expand to subagents.
 
-**Critical**: Always `cd` into the target directory first, then use VCC globs — a single `cd && python VCC.py <glob> --grep` is the correct pattern. Without `cd`, grep output contains full absolute paths instead of short relative paths, wasting tokens. All content search on JSONL must use VCC's `--grep`, never system grep or the embedded Grep tool — VCC's `--grep` returns block-level line ranges with role tags that no other grep can provide.
+**Critical**: Always `cd` into the target directory first, then use VCC globs — a single `cd && uv run VCC.py <glob> --grep` is the correct pattern. Without `cd`, grep output contains full absolute paths instead of short relative paths, wasting tokens. All content search on JSONL must use VCC's `--grep`, never system grep or the embedded Grep tool — VCC's `--grep` returns block-level line ranges with role tags that no other grep can provide.
 
 ## /recall — Recover context from a previous conversation
 

--- a/skills/conversation-compiler/scripts/VCC.py
+++ b/skills/conversation-compiler/scripts/VCC.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
 """View-oriented Conversation Compiler (VCC) - compile Claude JSONL logs into adaptive views.
 
 Produces per conversation chain:
@@ -7,12 +11,12 @@ Produces per conversation chain:
   .view.txt  View mode (search-focused, only with --grep)
 
 Usage:
-  python VCC.py conversation.jsonl              # .txt + .min.txt
-  python VCC.py conversation.jsonl --grep "kw"  # + .view.txt + stdout search hits
-  python VCC.py conversation.jsonl -t 128       # truncation limit (tokens, default 128)
-  python VCC.py conversation.jsonl -tu 256      # user message truncation limit (default 256)
-  python VCC.py conversation.jsonl -o outdir    # output directory
-  python VCC.py project/*.jsonl --grep "kw"     # multi-file search
+  uv run VCC.py conversation.jsonl              # .txt + .min.txt
+  uv run VCC.py conversation.jsonl --grep "kw"  # + .view.txt + stdout search hits
+  uv run VCC.py conversation.jsonl -t 128       # truncation limit (tokens, default 128)
+  uv run VCC.py conversation.jsonl -tu 256      # user message truncation limit (default 256)
+  uv run VCC.py conversation.jsonl -o outdir    # output directory
+  uv run project/*.jsonl --grep "kw"            # multi-file search
 """
 
 import argparse
@@ -22,7 +26,7 @@ import json
 import os
 import re
 import sys
-import yaml
+import yaml  # pyright: ignore[reportMissingModuleSource]
 
 import glob as globmod
 


### PR DESCRIPTION
Replace the requirement for users to `pip install pyyaml` on their system Python (which fails on externally-managed environments per PEP 668) with uv's PEP 723 inline script metadata. uv automatically handles the dependency in an isolated environment at runtime.

- Add inline script metadata (requires-python, dependencies) to VCC.py
- Change shebang to `#!/usr/bin/env -S uv run --script`
- Update all `python` invocations to `uv run` in SKILL.md
- Replace PyYAML install instruction with uv in INSTALL.md