### PR TITLE
Use yaml.CDumper for ~30% faster compilation

### DIFF
--- a/skills/conversation-compiler/scripts/VCC.py
+++ b/skills/conversation-compiler/scripts/VCC.py
@@ -39,7 +39,7 @@ def _str_representer(d, data):
         return d.represent_scalar("tag:yaml.org,2002:str", clean, style="|")
     return d.represent_scalar("tag:yaml.org,2002:str", data)
 
-class _dumper(yaml.Dumper):
+class _dumper(yaml.CDumper):
     pass
 
 _dumper.add_representer(str, _str_representer)


### PR DESCRIPTION
## One-word change, 30% faster

Thanks for building VCC lvmin! I found it interesting as I have been looking for a similar solution for my multiple quickly growing claude code repos with exploding context.  This helps to push it further yet simple. I did a number of perf tests on it based on my local cc session data and see if there's any quick win to ideally cut the latency to <1 sec and one of them is around yaml (I would argue for not using yaml as many json solutions seems to be significantly faster, but that might make certain semantics hard to implement with same parity)

`yaml.Dumper` → `yaml.CDumper` on line 42. That's the whole diff.

PyYAML ships with two backends: a pure-Python `Dumper` and a `CDumper` that wraps [libyaml](https://github.com/yaml/libyaml) (C). Both produce the same YAML — `CDumper` just does the heavy lifting (character analysis, scalar emission) in compiled C instead of Python bytecode.

VCC already requires `pyyaml` in INSTALL.md, and `pip install pyyaml` builds the C extension by default. So `CDumper` is already sitting there, just not being used.

### Why this matters

`_yaml_dump` serializes tool_call inputs during `parse()`. On a cProfile of 20 conversation chains, it accounts for **84% of parse time** — almost entirely in PyYAML's `analyze_scalar`, which does character-by-character scanning in Python to decide between `|`, `|-`, quoted, and plain styles:

```
ncalls  tottime  cumtime  filename:lineno(function)
  2683    0.003    2.290  yaml/__init__.py:248(dump)
 12935    1.017    1.174  yaml/emitter.py:626(analyze_scalar)
   917    0.453    0.589  yaml/emitter.py:1045(write_literal)
```

Switching to CDumper moves this into C. The custom `_str_representer` still runs in Python (it's a callback), but the expensive serialization path doesn't.

### Benchmark

255 JSONL files from real Claude Code sessions, 666 MB total. Full `compile_pass` pipeline with file writes, best of 3 runs.

| Mode | Before | After | Speedup |
|---|---|---|---|
| Normal (`.txt` + `.min.txt`) | 12.52s | 8.68s | **31% faster** |
| With `--grep` | 14.83s | 10.58s | **29% faster** |

Per-file the difference is small (median file has ~44 tool calls, yaml_dump costs 8.8ms). It adds up in batch search across project history.

### Output verification

Ran both versions on a 4.5 MB session file (4,794 lines `.txt`, 1,110 lines `.min.txt`):

- `.txt`: **0 line diffs**
- `.min.txt`: **0 line diffs**

Across all 19,368 tool_call inputs in the dataset, 98.9% produce byte-identical YAML. The 1.1% difference is CDumper escaping non-BMP emoji as `\U0001F534` where the Python Dumper passes `🔴` through directly. This only affects `.txt` display of emoji inside tool inputs — line structure, line counts, and searchability are unchanged.

### No new dependencies

`pyyaml` is already required. `CDumper` is part of the same package.
